### PR TITLE
Update pin placement command name

### DIFF
--- a/openroad/chip.tcl
+++ b/openroad/chip.tcl
@@ -126,7 +126,7 @@ source ../pdk/openroad/make_tracks.tcl
 
 # Place Pins
 if {[llength [all_inputs]] > 0 || [llength [all_outputs]] > 0} {
-    place_io_pins -hor_layers Metal1 -ver_layers Metal2 \
+    place_pins -hor_layers Metal1 -ver_layers Metal2 \
         -min_distance_in_tracks -min_distance 8
 }
 


### PR DESCRIPTION
The chip.tcl script no longer runs on current versions of OpenROAD as the place_io_pins command appears to have been renamed to simply place_pins.